### PR TITLE
Setup for atlas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+.env

--- a/config/connection.js
+++ b/config/connection.js
@@ -1,9 +1,9 @@
 const { connect, connection } = require('mongoose');
+const dotenv = require('dotenv');
 
-// After you create your Heroku application, visit https://dashboard.heroku.com/apps/ select the application name and add your Atlas connection string as a Config Var
-// Node will look for this environment variable and if it exists, it will use it. Otherwise, it will assume that you are running this application locally
-const connectionString =
-  process.env.MONGODB_URI; //|| 'mongodb://localhost:27017/studentsDB';
+dotenv.config();
+
+const connectionString = process.env.MONGODB_URI;
 
 connect(connectionString, {
   useNewUrlParser: true,

--- a/config/connection.js
+++ b/config/connection.js
@@ -3,7 +3,7 @@ const { connect, connection } = require('mongoose');
 // After you create your Heroku application, visit https://dashboard.heroku.com/apps/ select the application name and add your Atlas connection string as a Config Var
 // Node will look for this environment variable and if it exists, it will use it. Otherwise, it will assume that you are running this application locally
 const connectionString =
-  process.env.MONGODB_URI || 'mongodb://localhost:27017/studentsDB';
+  process.env.MONGODB_URI; //|| 'mongodb://localhost:27017/studentsDB';
 
 connect(connectionString, {
   useNewUrlParser: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
+        "dotenv": "^16.3.1",
         "express": "^4.17.1",
         "mongoose": "^6.0.13"
       },
@@ -1424,6 +1425,17 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/ee-first": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "heroku-postbuild": "node utils/seed.js"
   },
   "dependencies": {
+    "dotenv": "^16.3.1",
     "express": "^4.17.1",
     "mongoose": "^6.0.13"
   },


### PR DESCRIPTION
Outside of this branch I:
 - Set up a new cluster on Mongo Atlas 
 - Stored the MONGODB_URI for this cluster in a `.env` file locally

In this branch I:
 - Added the `.env` file to the `.gitignore`
 - Installed the `dotenv` package with `npm`
 - Imported this package into `connection.js`
 - Wrote code that would fetch the `MONGODB_URI` variable from the envrionment variables
 - Used this string to establish a connection with cluster on Mongo Atlas

I then ran tests already created in Postman.